### PR TITLE
feat: fn parserUA

### DIFF
--- a/js/ua.test.ts
+++ b/js/ua.test.ts
@@ -1,4 +1,5 @@
 import {
+  assertEquals,
   assertObjectMatch,
 } from 'https://deno.land/std@0.131.0/testing/asserts.ts';
 
@@ -8,6 +9,14 @@ const iPadUA =
   `Mozilla/5.0 (iPad; CPU OS 15_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/19H12 AliApp(DingTalk/6.5.45) com.laiwang.DingTalk/26191496 Channel/201200 Pad/iPad language/zh-Hans-CN UT4Aplus/0.0.6 WK`;
 const androidUA =
   `Mozilla/5.0 (Linux; U; Android 10; zh-CN; EVR-AL00 Build/HUAWEIEVR-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 UWS/3.22.1.210 Mobile Safari/537.36 AliApp(DingTalk/6.5.45) com.alibaba.android.rimet/26284409 Channel/227200 language/zh-CN abi/64 Hmos/1 UT4Aplus/0.2.25 colorScheme/light`;
+const macosUA =
+  `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36`;
+const iPhoneUA =
+  `Mozilla/5.0 (iPhone; CPU iPhone OS 15_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Mobile/15E148 Safari/604.1`;
+const windowsUA =
+  `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36`;
+const crUA =
+  `Mozilla/5.0 (X11; CrOS x86_64 14816.131.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36`;
 
 Deno.test('ua-dingtalk', () => {
   const iPadRes = parserUA(iPadUA);
@@ -22,10 +31,32 @@ Deno.test('ua-dingtalk', () => {
   });
 });
 
+Deno.test('ua-os', () => {
+  {
+    const res = parserUA(macosUA);
+    assertObjectMatch(res, { os: 'macOS' });
+  }
+  {
+    const res = parserUA(iPhoneUA);
+    assertObjectMatch(res, { os: 'iOS' });
+  }
+  {
+    const res = parserUA(windowsUA);
+    assertObjectMatch(res, { os: 'Windows' });
+  }
+
+  {
+    const res = parserUA(crUA);
+    assertObjectMatch(res, { os: 'Chrome OS' });
+  }
+});
+
 Deno.test('debug-parserUACommon', () => {
   const res1 = parserUACommon(iPadUA);
+  assertEquals(res1.length, 10);
   console.log('res1', res1);
 
   const res2 = parserUACommon(androidUA);
+  assertEquals(res2.length, 15);
   console.log('res2', res2);
 });

--- a/js/ua.test.ts
+++ b/js/ua.test.ts
@@ -1,0 +1,31 @@
+import {
+  assertObjectMatch,
+} from 'https://deno.land/std@0.131.0/testing/asserts.ts';
+
+import { parserUA, parserUACommon } from './ua.ts';
+
+const iPadUA =
+  `Mozilla/5.0 (iPad; CPU OS 15_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/19H12 AliApp(DingTalk/6.5.45) com.laiwang.DingTalk/26191496 Channel/201200 Pad/iPad language/zh-Hans-CN UT4Aplus/0.0.6 WK`;
+const androidUA =
+  `Mozilla/5.0 (Linux; U; Android 10; zh-CN; EVR-AL00 Build/HUAWEIEVR-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 UWS/3.22.1.210 Mobile Safari/537.36 AliApp(DingTalk/6.5.45) com.alibaba.android.rimet/26284409 Channel/227200 language/zh-CN abi/64 Hmos/1 UT4Aplus/0.2.25 colorScheme/light`;
+
+Deno.test('ua-dingtalk', () => {
+  const iPadRes = parserUA(iPadUA);
+  assertObjectMatch(iPadRes, { isDingtalk: true, dingtalkVersion: '6.5.45' });
+
+  const androidRes = parserUA(androidUA);
+  assertObjectMatch(androidRes, {
+    isDingtalk: true,
+    dingtalkVersion: '6.5.45',
+    isHmos: true,
+    hmosVersion: '1',
+  });
+});
+
+Deno.test('debug-parserUACommon', () => {
+  const res1 = parserUACommon(iPadUA);
+  console.log('res1', res1);
+
+  const res2 = parserUACommon(androidUA);
+  console.log('res2', res2);
+});

--- a/js/ua.test.ts
+++ b/js/ua.test.ts
@@ -9,6 +9,7 @@ const iPadUA =
   `Mozilla/5.0 (iPad; CPU OS 15_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/19H12 AliApp(DingTalk/6.5.45) com.laiwang.DingTalk/26191496 Channel/201200 Pad/iPad language/zh-Hans-CN UT4Aplus/0.0.6 WK`;
 const androidUA =
   `Mozilla/5.0 (Linux; U; Android 10; zh-CN; EVR-AL00 Build/HUAWEIEVR-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 UWS/3.22.1.210 Mobile Safari/537.36 AliApp(DingTalk/6.5.45) com.alibaba.android.rimet/26284409 Channel/227200 language/zh-CN abi/64 Hmos/1 UT4Aplus/0.2.25 colorScheme/light`;
+const androidRes = parserUA(androidUA);
 const macosUA =
   `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36`;
 const iPhoneUA =
@@ -17,17 +18,29 @@ const windowsUA =
   `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36`;
 const crUA =
   `Mozilla/5.0 (X11; CrOS x86_64 14816.131.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36`;
+const weixinUA =
+  `Mozilla/5.0 (Linux; Android 7.0; FRD-AL00 Build/HUAWEIFRD-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043602 Safari/537.36 MicroMessenger/6.5.16.1120 NetType/WIFI Language/zh_CN`;
+const workweixinUA =
+  `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G60 wxwork/2.1.5 MicroMessenger/6.3.22`;
 
 Deno.test('ua-dingtalk', () => {
   const iPadRes = parserUA(iPadUA);
   assertObjectMatch(iPadRes, { isDingtalk: true, dingtalkVersion: '6.5.45' });
 
-  const androidRes = parserUA(androidUA);
   assertObjectMatch(androidRes, {
     isDingtalk: true,
     dingtalkVersion: '6.5.45',
-    isHmos: true,
-    hmosVersion: '1',
+  });
+});
+
+Deno.test('ua-weixin', () => {
+  const weixinRes = parserUA(weixinUA);
+  assertObjectMatch(weixinRes, { isWeixin: true });
+
+  const workweixinRes = parserUA(workweixinUA);
+  assertObjectMatch(workweixinRes, {
+    isWeixin: false,
+    isWorkWeixin: true,
   });
 });
 
@@ -44,11 +57,14 @@ Deno.test('ua-os', () => {
     const res = parserUA(windowsUA);
     assertObjectMatch(res, { os: 'Windows' });
   }
-
   {
     const res = parserUA(crUA);
     assertObjectMatch(res, { os: 'Chrome OS' });
   }
+  assertObjectMatch(androidRes, {
+    os: 'HarmonyOS',
+    hmosVersion: '1',
+  });
 });
 
 Deno.test('debug-parserUACommon', () => {

--- a/js/ua.test.ts
+++ b/js/ua.test.ts
@@ -22,25 +22,36 @@ const weixinUA =
   `Mozilla/5.0 (Linux; Android 7.0; FRD-AL00 Build/HUAWEIFRD-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043602 Safari/537.36 MicroMessenger/6.5.16.1120 NetType/WIFI Language/zh_CN`;
 const workweixinUA =
   `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G60 wxwork/2.1.5 MicroMessenger/6.3.22`;
+const alipayUA =
+  `Mozilla/5.0 (Linux; U; Android 10; zh-CN; H9493 Build/52.1.A.3.49) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 UWS/3.21.0.169 Mobile Safari/537.36 AlipayChannelId/5136 UCBS/3.21.0.169_200731162109 NebulaSDK/1.8.100112 Nebula AlipayDefined(nt:WIFI,ws:411|0|3.5,ac:sp) AliApp(AP/10.2.0.8026) AlipayClient/10.2.0.8026 Language/zh-Hans useStatusBar/true isConcaveScreen/false Region/CN NebulaX/1.0.0 Ariver/1.0.0`;
+const alipayRes = parserUA(alipayUA);
 
 Deno.test('ua-dingtalk', () => {
   const iPadRes = parserUA(iPadUA);
-  assertObjectMatch(iPadRes, { isDingtalk: true, dingtalkVersion: '6.5.45' });
+  assertObjectMatch(iPadRes, {
+    isDingtalk: true,
+    dingtalkVersion: '6.5.45',
+    softwareName: '钉钉',
+  });
 
   assertObjectMatch(androidRes, {
     isDingtalk: true,
     dingtalkVersion: '6.5.45',
+    softwareName: '钉钉',
   });
+});
+
+Deno.test('ua-alipay', () => {
+  assertObjectMatch(alipayRes, { softwareName: '支付宝' });
 });
 
 Deno.test('ua-weixin', () => {
   const weixinRes = parserUA(weixinUA);
-  assertObjectMatch(weixinRes, { isWeixin: true });
+  assertObjectMatch(weixinRes, { softwareName: '微信' });
 
   const workweixinRes = parserUA(workweixinUA);
   assertObjectMatch(workweixinRes, {
-    isWeixin: false,
-    isWorkWeixin: true,
+    softwareName: '企业微信',
   });
 });
 

--- a/js/ua.test.ts
+++ b/js/ua.test.ts
@@ -25,8 +25,11 @@ const workweixinUA =
 const alipayUA =
   `Mozilla/5.0 (Linux; U; Android 10; zh-CN; H9493 Build/52.1.A.3.49) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 UWS/3.21.0.169 Mobile Safari/537.36 AlipayChannelId/5136 UCBS/3.21.0.169_200731162109 NebulaSDK/1.8.100112 Nebula AlipayDefined(nt:WIFI,ws:411|0|3.5,ac:sp) AliApp(AP/10.2.0.8026) AlipayClient/10.2.0.8026 Language/zh-Hans useStatusBar/true isConcaveScreen/false Region/CN NebulaX/1.0.0 Ariver/1.0.0`;
 const alipayRes = parserUA(alipayUA);
+const feishuUA =
+  `Mozilla/5.0 (iPhone; CPU iPhone OS 15_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Mobile/15E148 Safari/604.1 Lark/5.21.3 LarkLocale/zh_CN ChannelName/Feishu LKBrowserIdentifier/3CDCC4D9-6106-40EF-97E2-F39C858C6E03`;
+const feishuRes = parserUA(feishuUA);
 
-Deno.test('ua-dingtalk', () => {
+Deno.test('ua-sw', () => {
   const iPadRes = parserUA(iPadUA);
   assertObjectMatch(iPadRes, {
     isDingtalk: true,
@@ -39,19 +42,19 @@ Deno.test('ua-dingtalk', () => {
     dingtalkVersion: '6.5.45',
     softwareName: '钉钉',
   });
-});
 
-Deno.test('ua-alipay', () => {
   assertObjectMatch(alipayRes, { softwareName: '支付宝' });
-});
 
-Deno.test('ua-weixin', () => {
   const weixinRes = parserUA(weixinUA);
   assertObjectMatch(weixinRes, { softwareName: '微信' });
 
   const workweixinRes = parserUA(workweixinUA);
   assertObjectMatch(workweixinRes, {
     softwareName: '企业微信',
+  });
+
+  assertObjectMatch(feishuRes, {
+    softwareName: '飞书',
   });
 });
 

--- a/js/ua.ts
+++ b/js/ua.ts
@@ -1,37 +1,84 @@
+type OSName =
+  | 'macOS'
+  | 'Windows'
+  | 'Android'
+  | 'HarmonyOS'
+  | 'iOS'
+  | 'iPadOS'
+  | 'Chrome OS'
+  | 'unknown';
+
 export function parserUA(ua: string): {
   isDingtalk: boolean;
   dingtalkVersion: string | null;
-  isHmos: boolean;
   hmosVersion: string | null;
+  isMobile: boolean;
+  os: OSName;
 } {
   const base = Object.fromEntries(
     parserUACommon(ua).map(({ key, ...rest }) => [key, rest]),
   );
+
+  let os: OSName = 'unknown';
+
   let isDingtalk = false;
   let dingtalkVersion: string | null = null;
-  {
-    const aliapp = base['AliApp'];
-    if (aliapp && aliapp.info.length === 1) {
-      // 根据真实 UA 猜测, 如果阿里将来 UA 变动, 可能导致出错
-      const [{ key, version }] = parserUACommon(aliapp.info[0]);
-      if (key === 'DingTalk') {
-        isDingtalk = true;
-        dingtalkVersion = version!;
-      }
+  const aliapp = base['AliApp'];
+  if (aliapp && aliapp.info.length === 1) {
+    // 根据真实 UA 猜测, 如果阿里将来 UA 变动, 可能导致出错
+    const [{ key, version }] = parserUACommon(aliapp.info[0]);
+    if (key === 'DingTalk') {
+      isDingtalk = true;
+      dingtalkVersion = version!;
     }
   }
 
-  let isHmos = false;
+  // 简单判断 OS 信息
+  for (const info of base['Mozilla'].info) {
+    // TODO: 从 13 开始, 改名为 iPadOS
+    if (info === 'iPad') {
+      os = 'iPadOS';
+      break;
+    }
+    if (info === 'iPhone') {
+      os = 'iOS';
+      break;
+    }
+    if (info === 'Macintosh') {
+      os = 'macOS';
+      break;
+    }
+    if (info.startsWith('Windows NT')) {
+      os = 'Windows';
+      break;
+    }
+    if (info.startsWith('Android')) {
+      os = 'Android';
+      break;
+    }
+    if (info.startsWith('CrOS')) {
+      os = 'Chrome OS';
+      break;
+    }
+  }
+
+  // TODO: 判断是否为 Android
+  //       (注意, 一定要在判断 hmos 之前, 否则会因兼容导致误判)
+
   let hmosVersion: string | null = null;
-  {
-    const hmos = base['Hmos'];
-    if (hmos) {
-      isHmos = true;
-      hmosVersion = hmos.version!;
-    }
+  const hmos = base['Hmos'];
+  if (hmos) {
+    os = 'HarmonyOS';
+    hmosVersion = hmos.version!;
   }
 
-  return { isDingtalk, dingtalkVersion, isHmos, hmosVersion };
+  return {
+    isDingtalk,
+    dingtalkVersion,
+    hmosVersion,
+    isMobile: base['Mobile'] !== undefined,
+    os,
+  };
 }
 
 export function parserUACommon(

--- a/js/ua.ts
+++ b/js/ua.ts
@@ -4,11 +4,13 @@ export function parserUA(ua: string): {
   isHmos: boolean;
   hmosVersion: string | null;
 } {
-  const base = parserUACommon(ua);
+  const base = Object.fromEntries(
+    parserUACommon(ua).map(({ key, ...rest }) => [key, rest]),
+  );
   let isDingtalk = false;
   let dingtalkVersion: string | null = null;
   {
-    const aliapp = base.find((v) => v.key === 'AliApp');
+    const aliapp = base['AliApp'];
     if (aliapp && aliapp.info.length === 1) {
       // 根据真实 UA 猜测, 如果阿里将来 UA 变动, 可能导致出错
       const [{ key, version }] = parserUACommon(aliapp.info[0]);
@@ -22,7 +24,7 @@ export function parserUA(ua: string): {
   let isHmos = false;
   let hmosVersion: string | null = null;
   {
-    const hmos = base.find((v) => v.key === 'Hmos');
+    const hmos = base['Hmos'];
     if (hmos) {
       isHmos = true;
       hmosVersion = hmos.version!;

--- a/js/ua.ts
+++ b/js/ua.ts
@@ -33,7 +33,7 @@ export function parserUA(ua: string): {
     }
   }
 
-  // 简单判断 OS 信息
+  // 简单识别 OS 信息
   for (const info of base['Mozilla'].info) {
     // TODO: 从 13 开始, 改名为 iPadOS
     if (info === 'iPad') {
@@ -62,9 +62,7 @@ export function parserUA(ua: string): {
     }
   }
 
-  // TODO: 判断是否为 Android
-  //       (注意, 一定要在判断 hmos 之前, 否则会因兼容导致误判)
-
+  // 鸿蒙 OS 识别
   let hmosVersion: string | null = null;
   const hmos = base['Hmos'];
   if (hmos) {

--- a/js/ua.ts
+++ b/js/ua.ts
@@ -1,0 +1,74 @@
+export function parserUA(ua: string): {
+  isDingtalk: boolean;
+  dingtalkVersion: string | null;
+  isHmos: boolean;
+  hmosVersion: string | null;
+} {
+  const base = parserUACommon(ua);
+  let isDingtalk = false;
+  let dingtalkVersion: string | null = null;
+  {
+    const aliapp = base.find((v) => v.key === 'AliApp');
+    if (aliapp && aliapp.info.length === 1) {
+      // 根据真实 UA 猜测, 如果阿里将来 UA 变动, 可能导致出错
+      const [{ key, version }] = parserUACommon(aliapp.info[0]);
+      if (key === 'DingTalk') {
+        isDingtalk = true;
+        dingtalkVersion = version!;
+      }
+    }
+  }
+
+  let isHmos = false;
+  let hmosVersion: string | null = null;
+  {
+    const hmos = base.find((v) => v.key === 'Hmos');
+    if (hmos) {
+      isHmos = true;
+      hmosVersion = hmos.version!;
+    }
+  }
+
+  return { isDingtalk, dingtalkVersion, isHmos, hmosVersion };
+}
+
+export function parserUACommon(
+  ua: string,
+): { key: string; version?: string; info: string[] }[] {
+  const arr: { key: string; version?: string; info: string[] }[] = [];
+  let temp = '';
+  let isBlock = false;
+
+  const insert = () => {
+    if (!temp) {
+      return;
+    }
+    const [key, version] = temp.split('/');
+    arr.push({ key, version, info: [] });
+    temp = '';
+  };
+  for (const s of ua) {
+    if (s === '(') {
+      // 开始附加信息
+      isBlock = true;
+
+      // 处理特定情况附加信息前没有空格的问题
+      insert();
+    } else if (s === ')') {
+      // 结束附加信息写入
+      isBlock = false;
+      arr[arr.length - 1].info.push(...temp.split(';').map((v) => v.trim()));
+      temp = '';
+    } else if (s === ' ' && !isBlock) {
+      // 结束一段信息
+      insert();
+    } else if (!temp && s === ' ') {
+      // 避免首位空字符串写入
+      continue;
+    } else {
+      temp += s;
+    }
+  }
+  insert();
+  return arr;
+}

--- a/js/ua.ts
+++ b/js/ua.ts
@@ -8,7 +8,7 @@ type OSName =
   | 'Chrome OS'
   | 'unknown';
 
-type SoftwareName = '钉钉' | '支付宝' | '微信' | '企业微信' | 'unknown';
+type SoftwareName = '钉钉' | '支付宝' | '微信' | '企业微信' | '飞书' | 'Lark' | 'unknown';
 
 export function parserUA(ua: string): {
   isDingtalk: boolean;
@@ -83,6 +83,13 @@ export function parserUA(ua: string): {
   }
   if (base['wxwork']) {
     softwareName = '企业微信';
+  }
+
+  if (base['Lark']) {
+    softwareName = 'Lark';
+    if (base['ChannelName'].version === 'Feishu') {
+      softwareName = '飞书';
+    }
   }
 
   return {

--- a/js/ua.ts
+++ b/js/ua.ts
@@ -8,20 +8,22 @@ type OSName =
   | 'Chrome OS'
   | 'unknown';
 
+type SoftwareName = '钉钉' | '支付宝' | '微信' | '企业微信' | 'unknown';
+
 export function parserUA(ua: string): {
   isDingtalk: boolean;
   dingtalkVersion: string | null;
   hmosVersion: string | null;
   isMobile: boolean;
   os: OSName;
-  isWeixin: boolean;
-  isWorkWeixin: boolean;
+  softwareName: SoftwareName;
 } {
   const base = Object.fromEntries(
     parserUACommon(ua).map(({ key, ...rest }) => [key, rest]),
   );
 
   let os: OSName = 'unknown';
+  let softwareName: SoftwareName = 'unknown';
 
   let isDingtalk = false;
   let dingtalkVersion: string | null = null;
@@ -32,6 +34,10 @@ export function parserUA(ua: string): {
     if (key === 'DingTalk') {
       isDingtalk = true;
       dingtalkVersion = version!;
+      softwareName = '钉钉';
+    }
+    if (key === 'AP') {
+      softwareName = '支付宝';
     }
   }
 
@@ -72,14 +78,11 @@ export function parserUA(ua: string): {
     hmosVersion = hmos.version!;
   }
 
-  let isWeixin = false;
   if (base['MicroMessenger']) {
-    isWeixin = true;
+    softwareName = '微信';
   }
-  let isWorkWeixin = false;
   if (base['wxwork']) {
-    isWeixin = false;
-    isWorkWeixin = true;
+    softwareName = '企业微信';
   }
 
   return {
@@ -88,8 +91,7 @@ export function parserUA(ua: string): {
     hmosVersion,
     isMobile: base['Mobile'] !== undefined,
     os,
-    isWeixin,
-    isWorkWeixin,
+    softwareName,
   };
 }
 

--- a/js/ua.ts
+++ b/js/ua.ts
@@ -14,6 +14,8 @@ export function parserUA(ua: string): {
   hmosVersion: string | null;
   isMobile: boolean;
   os: OSName;
+  isWeixin: boolean;
+  isWorkWeixin: boolean;
 } {
   const base = Object.fromEntries(
     parserUACommon(ua).map(({ key, ...rest }) => [key, rest]),
@@ -70,12 +72,24 @@ export function parserUA(ua: string): {
     hmosVersion = hmos.version!;
   }
 
+  let isWeixin = false;
+  if (base['MicroMessenger']) {
+    isWeixin = true;
+  }
+  let isWorkWeixin = false;
+  if (base['wxwork']) {
+    isWeixin = false;
+    isWorkWeixin = true;
+  }
+
   return {
     isDingtalk,
     dingtalkVersion,
     hmosVersion,
     isMobile: base['Mobile'] !== undefined,
     os,
+    isWeixin,
+    isWorkWeixin,
   };
 }
 


### PR DESCRIPTION
主要解决当前主流 UA 解析库不支持如下中国特色的问题:

- 钉钉判断
- 微信判断
- 企业微信判断
- 飞书判断
- 支付宝判断